### PR TITLE
Enable users to join with more than one instance at the same time and host multiple games

### DIFF
--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -43,7 +43,7 @@ class TestGames(TestCase):
         all_games = games.get_all_games()
         game_data.update({'players-init': game_data['players'], 'nbp-init': game_data['nbp'],
                           'state': game_data['state']})
-        self.assertDictEqual(all_games, {jid: game_data})
+        self.assertDictEqual(all_games, {jid: {jid.resource: game_data}})
 
     @parameterized.expand([
         ('', {}),
@@ -70,9 +70,9 @@ class TestGames(TestCase):
                            'state': game_data1['state']})
         game_data2.update({'players-init': game_data2['players'], 'nbp-init': game_data2['nbp'],
                            'state': game_data2['state']})
-        self.assertDictEqual(games.get_all_games(), {jid1: game_data1, jid2: game_data2})
+        self.assertDictEqual(games.get_all_games(), {jid1: {jid1.resource: game_data1}, jid2: {jid2.resource: game_data2}})
         games.remove_game(jid1)
-        self.assertDictEqual(games.get_all_games(), {jid2: game_data2})
+        self.assertDictEqual(games.get_all_games(), {jid2: {jid2.resource: game_data2}})
         games.remove_game(jid2)
         self.assertDictEqual(games.get_all_games(), dict())
 

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -76,6 +76,85 @@ class TestGames(TestCase):
         games.remove_game(jid2)
         self.assertListEqual(games.get_all_games(), [])
 
+    def test_remove_all_games_for_jid(self):
+        """Test removal of all games belonging to a jid."""
+        games = Games()
+
+        jids = []
+
+        jids.append(JID(jid="player1@domain.tld", resource="0ad-asdf1234"))
+        jids.append(JID(jid="player1@domain.tld", resource="0ad-qwer2345"))
+        jids.append(JID(jid="player1@domain.tld", resource="0ad-zxcv3456"))
+        jids.append(JID(jid="player2@domain.tld", resource="0ad-tyui4567"))
+        jids.append(JID(jid="player3@domain.tld", resource="0ad-ghjk5678"))
+        jids.append(JID(jid="player4@domain.tld", resource="0ad-bnmp6789"))
+
+        game_data1 = {'players': ['player1', 'player2'], 'nbp': 'foo', 'state': 'init'}
+        games.add_game(jids[0], game_data1)
+        game_data2 = {'players': ['player3', 'player4'], 'nbp': 'bar', 'state': 'init'}
+        games.add_game(jids[1], game_data2)
+        game_data3 = {'players': ['player5', 'player6'], 'nbp': 'bar', 'state': 'init'}
+        games.add_game(jids[2], game_data3)
+        game_data4 = {'players': ['player7', 'player8'], 'nbp': 'foo', 'state': 'init'}
+        games.add_game(jids[3], game_data4)
+        game_data5 = {'players': ['player9', 'playera'], 'nbp': 'bar', 'state': 'init'}
+        games.add_game(jids[4], game_data5)
+        game_data6 = {'players': ['playerb', 'playerc'], 'nbp': 'bar', 'state': 'init'}
+        games.add_game(jids[5], game_data6)
+
+        game_data1.update({'players-init': game_data1['players'],
+                           'nbp-init': game_data1['nbp'],
+                           'state': game_data1['state']})
+        game_data2.update({'players-init': game_data2['players'],
+                           'nbp-init': game_data2['nbp'],
+                           'state': game_data2['state']})
+        game_data3.update({'players-init': game_data3['players'],
+                           'nbp-init': game_data3['nbp'],
+                           'state': game_data3['state']})
+        game_data4.update({'players-init': game_data4['players'],
+                           'nbp-init': game_data4['nbp'],
+                           'state': game_data4['state']})
+        game_data5.update({'players-init': game_data5['players'],
+                           'nbp-init': game_data5['nbp'],
+                           'state': game_data5['state']})
+        game_data6.update({'players-init': game_data6['players'],
+                           'nbp-init': game_data6['nbp'],
+                           'state': game_data6['state']})
+
+        expected_games_dict = {
+            jids[0].bare: {jids[0].resource: game_data1, jids[1].resource: game_data2,
+                           jids[2].resource: game_data3},
+            jids[3].bare: {jids[3].resource: game_data4},
+            jids[4].bare: {jids[4].resource: game_data5},
+            jids[5].bare: {jids[5].resource: game_data6}}
+        self.assertDictEqual(expected_games_dict, games.games)
+
+        expected_games_list = [game
+                               for jid, dict_of_resources_and_games
+                               in sorted(expected_games_dict.items(),
+                                         key=lambda item: item[0])      # sort by jid
+                               for resource, game
+                               in sorted(dict_of_resources_and_games.items(),
+                                         key=lambda item: item[0])]     # sort by resource
+        self.assertListEqual(games.get_all_games(), expected_games_list)
+
+        games.remove_all_games_for_jid(jids[0])
+
+        expected_games_dict = {
+            jids[3].bare: {jids[3].resource: game_data4},
+            jids[4].bare: {jids[4].resource: game_data5},
+            jids[5].bare: {jids[5].resource: game_data6}}
+        self.assertDictEqual(expected_games_dict, games.games)
+
+        expected_games_list = [game
+                               for jid, dict_of_resources_and_games
+                               in sorted(expected_games_dict.items(),
+                                         key=lambda item: item[0])      # sort by jid
+                               for resource, game
+                               in sorted(dict_of_resources_and_games.items(),
+                                         key=lambda item: item[0])]     # sort by resource
+        self.assertListEqual(games.get_all_games(), expected_games_list)
+
     def test_remove_unknown(self):
         """Test removal of a game, which doesn't exist."""
         games = Games()

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -43,7 +43,7 @@ class TestGames(TestCase):
         all_games = games.get_all_games()
         game_data.update({'players-init': game_data['players'], 'nbp-init': game_data['nbp'],
                           'state': game_data['state']})
-        self.assertDictEqual(all_games, {jid.bare: {jid.resource: game_data}})
+        self.assertListEqual(all_games, [game_data])
 
     @parameterized.expand([
         ('', {}),
@@ -70,11 +70,11 @@ class TestGames(TestCase):
                            'state': game_data1['state']})
         game_data2.update({'players-init': game_data2['players'], 'nbp-init': game_data2['nbp'],
                            'state': game_data2['state']})
-        self.assertDictEqual(games.get_all_games(), {jid1.bare: {jid1.resource: game_data1}, jid2.bare: {jid2.resource: game_data2}})
+        self.assertListEqual(games.get_all_games(), [game_data1, game_data2])
         games.remove_game(jid1)
-        self.assertDictEqual(games.get_all_games(), {jid2.bare: {jid2.resource: game_data2}})
+        self.assertListEqual(games.get_all_games(), [game_data2])
         games.remove_game(jid2)
-        self.assertDictEqual(games.get_all_games(), dict())
+        self.assertListEqual(games.get_all_games(), [])
 
     def test_remove_unknown(self):
         """Test removal of a game, which doesn't exist."""

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -36,20 +36,20 @@ class TestGames(TestCase):
     def test_add(self):
         """Test successfully adding a game."""
         games = Games()
-        jid = JID(jid='player1@domain.tld')
+        jid = JID(jid='player1@domain.tld/0ad-asdf1234')
         # TODO: Check how the real format of data looks like
         game_data = {'players': ['player1', 'player2'], 'nbp': 'foo', 'state': 'init'}
         self.assertTrue(games.add_game(jid, game_data))
         all_games = games.get_all_games()
         game_data.update({'players-init': game_data['players'], 'nbp-init': game_data['nbp'],
                           'state': game_data['state']})
-        self.assertDictEqual(all_games, {jid: {jid.resource: game_data}})
+        self.assertDictEqual(all_games, {jid.bare: {jid.resource: game_data}})
 
     @parameterized.expand([
         ('', {}),
-        ('player1@domain.tld', {}),
-        ('player1@domain.tld', None),
-        ('player1@domain.tld', ''),
+        ('player1@domain.tld/0ad-asdf1234', {}),
+        ('player1@domain.tld/0ad-asdf1234', None),
+        ('player1@domain.tld/0ad-asdf1234', ''),
     ])
     def test_add_invalid(self, jid, game_data):
         """Test trying to add games with invalid data."""
@@ -59,8 +59,8 @@ class TestGames(TestCase):
     def test_remove(self):
         """Test removal of games."""
         games = Games()
-        jid1 = JID(jid='player1@domain.tld')
-        jid2 = JID(jid='player3@domain.tld')
+        jid1 = JID(jid='player1@domain.tld/0ad-asdf1234')
+        jid2 = JID(jid='player3@domain.tld/0ad-qwer2345')
         # TODO: Check how the real format of data looks like
         game_data1 = {'players': ['player1', 'player2'], 'nbp': 'foo', 'state': 'init'}
         games.add_game(jid1, game_data1)
@@ -70,20 +70,20 @@ class TestGames(TestCase):
                            'state': game_data1['state']})
         game_data2.update({'players-init': game_data2['players'], 'nbp-init': game_data2['nbp'],
                            'state': game_data2['state']})
-        self.assertDictEqual(games.get_all_games(), {jid1: {jid1.resource: game_data1}, jid2: {jid2.resource: game_data2}})
+        self.assertDictEqual(games.get_all_games(), {jid1.bare: {jid1.resource: game_data1}, jid2.bare: {jid2.resource: game_data2}})
         games.remove_game(jid1)
-        self.assertDictEqual(games.get_all_games(), {jid2: {jid2.resource: game_data2}})
+        self.assertDictEqual(games.get_all_games(), {jid2.bare: {jid2.resource: game_data2}})
         games.remove_game(jid2)
         self.assertDictEqual(games.get_all_games(), dict())
 
     def test_remove_unknown(self):
         """Test removal of a game, which doesn't exist."""
         games = Games()
-        jid = JID(jid='player1@domain.tld')
+        jid = JID('player1@domain.tld/0ad-asdf1234')
         # TODO: Check how the real format of data looks like
         game_data = {'players': ['player1', 'player2'], 'nbp': 'foo', 'state': 'init'}
         games.add_game(jid, game_data)
-        self.assertFalse(games.remove_game(JID('foo@bar.tld')))
+        self.assertFalse(games.remove_game(JID('foo@bar.tld/0ad-qwer2345')))
 
     def test_change_state(self):
         """Test state changes of a games."""

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -127,16 +127,7 @@ class TestGames(TestCase):
             jids[3].bare: {jids[3].resource: game_data4},
             jids[4].bare: {jids[4].resource: game_data5},
             jids[5].bare: {jids[5].resource: game_data6}}
-        self.assertDictEqual(expected_games_dict, games.games)
-
-        expected_games_list = [game
-                               for jid, dict_of_resources_and_games
-                               in sorted(expected_games_dict.items(),
-                                         key=lambda item: item[0])      # sort by jid
-                               for resource, game
-                               in sorted(dict_of_resources_and_games.items(),
-                                         key=lambda item: item[0])]     # sort by resource
-        self.assertListEqual(games.get_all_games(), expected_games_list)
+        self.assertDictEqual(games.games, expected_games_dict)
 
         games.remove_all_games_for_jid(jids[0])
 
@@ -145,15 +136,6 @@ class TestGames(TestCase):
             jids[4].bare: {jids[4].resource: game_data5},
             jids[5].bare: {jids[5].resource: game_data6}}
         self.assertDictEqual(expected_games_dict, games.games)
-
-        expected_games_list = [game
-                               for jid, dict_of_resources_and_games
-                               in sorted(expected_games_dict.items(),
-                                         key=lambda item: item[0])      # sort by jid
-                               for resource, game
-                               in sorted(dict_of_resources_and_games.items(),
-                                         key=lambda item: item[0])]     # sort by resource
-        self.assertListEqual(games.get_all_games(), expected_games_list)
 
     def test_remove_unknown(self):
         """Test removal of a game, which doesn't exist."""

--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -524,9 +524,6 @@ class EcheLOn(sleekxmpp.ClientXMPP):
         if nick == self.nick:
             return
 
-        if jid.resource != '0ad':
-            return
-
         self.leaderboard.get_or_create_player(jid)
 
         self._broadcast_rating_list()
@@ -573,8 +570,6 @@ class EcheLOn(sleekxmpp.ClientXMPP):
             iq (sleekxmpp.stanza.iq.IQ): Received IQ stanza
 
         """
-        if iq['from'].resource not in ['0ad']:
-            return
 
         command = iq['boardlist']['command']
         self.leaderboard.get_or_create_player(iq['from'])
@@ -597,8 +592,6 @@ class EcheLOn(sleekxmpp.ClientXMPP):
             iq (sleekxmpp.stanza.iq.IQ): Received IQ stanza
 
         """
-        if iq['from'].resource not in ['0ad']:
-            return
 
         try:
             self.report_manager.add_report(iq['from'], iq['gamereport']['game'])
@@ -619,8 +612,6 @@ class EcheLOn(sleekxmpp.ClientXMPP):
             iq (sleekxmpp.stanza.iq.IQ): Received IQ stanza
 
         """
-        if iq['from'].resource not in ['0ad']:
-            return
 
         try:
             self._send_profile(iq, iq['profile']['command'])

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -141,23 +141,25 @@ class Games:
             logging.warning("Tried to change state for non-existent game %s", jid)
             return False
 
+        game = self.games[jid.bare][jid.resource]
+
         try:
-            if self.games[jid]['nbp-init'] > data['nbp']:
+            if game['nbp-init'] > data['nbp']:
                 logging.debug("change game (%s) state from %s to %s", jid,
-                              self.games[jid]['state'], 'waiting')
-                self.games[jid]['state'] = 'waiting'
+                              game['state'], 'waiting')
+                game['state'] = 'waiting'
             else:
                 logging.debug("change game (%s) state from %s to %s", jid,
-                              self.games[jid]['state'], 'running')
-                self.games[jid]['state'] = 'running'
-            self.games[jid]['nbp'] = data['nbp']
-            self.games[jid]['players'] = data['players']
+                              game['state'], 'running')
+                game['state'] = 'running'
+            game['nbp'] = data['nbp']
+            game['players'] = data['players']
         except (KeyError, ValueError):
             logging.warning("Received invalid data for change game state from 0ad: %s", data)
             return False
         else:
-            if 'startTime' not in self.games[jid]:
-                self.games[jid]['startTime'] = str(round(time.time()))
+            if 'startTime' not in game:
+                game['startTime'] = str(round(time.time()))
             return True
 
 

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -95,11 +95,16 @@ class Games:
         """Return all games.
 
         Returns:
-            dict containing all games with the JID of the player who
-            started the game as key.
+            list containing all games. Sorted by jid then by resource.
 
         """
-        return self.games
+        return [game
+                for jid, dict_of_resources_and_games
+                in sorted(self.games.items(),
+                          key=lambda item: item[0])         # sort by jid
+                for resource, game
+                in sorted(dict_of_resources_and_games.items(),
+                          key=lambda item: item[0])]        # sort by resource
 
     def change_game_state(self, jid, data):
         """Switch game state between running and waiting.
@@ -247,7 +252,6 @@ class XpartaMuPP(sleekxmpp.ClientXMPP):
             iq (sleekxmpp.stanza.iq.IQ): Received IQ stanza
 
         """
-
         success = False
 
         command = iq['gamelist']['command']
@@ -284,9 +288,8 @@ class XpartaMuPP(sleekxmpp.ClientXMPP):
         games = self.games.get_all_games()
 
         stanza = GameListXmppPlugin()
-        for jid in games:
-            for resource in jid:
-               stanza.add_game(games[jid][resource])
+        for game in games:
+            stanza.add_game(game)
 
         if not to:
             for nick in self.plugin['xep_0045'].getRoster(self.room):

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -91,6 +91,25 @@ class Games:
         else:
             return True
 
+    def remove_all_games_for_jid(self, jid):
+        """Remove all games attached to the bare version of the JID.
+
+        Arguments:
+            jid (sleekxmpp.jid.JID): JID of the player whose games to
+                remove.
+
+        Returns:
+            True if removing the games succeeded, False if not
+
+        """
+        try:
+            del self.games[jid.bare]
+        except KeyError:
+            logging.warning("No games for jid %s exist", jid)
+            return False
+        else:
+            return True
+
     def get_all_games(self):
         """Return all games.
 
@@ -223,7 +242,7 @@ class XpartaMuPP(sleekxmpp.ClientXMPP):
         if nick == self.nick:
             return
 
-        if self.games.remove_game(jid):
+        if self.games.remove_all_games_for_jid(jid):
             self._send_game_list()
 
         logging.debug("Client '%s' with nick '%s' disconnected", jid, nick)

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -114,16 +114,15 @@ class Games:
         """Return all games.
 
         Returns:
-            list containing all games. Sorted by jid then by resource.
+            list containing all games.
 
         """
-        return [game
-                for jid, dict_of_resources_and_games
-                in sorted(self.games.items(),
-                          key=lambda item: item[0])         # sort by jid
-                for resource, game
-                in sorted(dict_of_resources_and_games.items(),
-                          key=lambda item: item[0])]        # sort by resource
+        games = []
+        for _, games_by_resource in self.games.items():
+            for _, game in games_by_resource.items():
+                games.append(game)
+
+        return games
 
     def change_game_state(self, jid, data):
         """Switch game state between running and waiting.

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -197,9 +197,6 @@ class XpartaMuPP(sleekxmpp.ClientXMPP):
         if nick == self.nick:
             return
 
-        if jid.resource not in ['0ad', 'CC']:
-            return
-
         self._send_game_list(jid)
 
         logging.debug("Client '%s' connected with a nick '%s'.", jid, nick)
@@ -250,8 +247,6 @@ class XpartaMuPP(sleekxmpp.ClientXMPP):
             iq (sleekxmpp.stanza.iq.IQ): Received IQ stanza
 
         """
-        if iq['from'].resource != '0ad':
-            return
 
         success = False
 


### PR DESCRIPTION
The 0 A.D. client has been improved to connect with a different resource for every new instance started. This allows for hosting multiple games at the same time.
This will also help with dedicated hosting to allow for multiple users to spawn and control remote instances of hosted matches.

Note: The change inside the 0 A.D. client might make it be hard or impossible to relist a game that disappeared from the list after a host got disconnected from the lobby server. To help with this, the 0 A.D. client might need to have a feature added to enable someone to reuse a previously used resource.