### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           - --diff
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
       - id: forbid-crlf
       - id: forbid-tabs
@@ -48,7 +48,7 @@ repos:
           - .
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.2.4
+    rev: v1.3.0
     hooks:
       - id: python-safety-dependencies-check
 


### PR DESCRIPTION
This updates the pre-commit hooks once more after the recent update, as
the pre-commit hook for safety broke with the recently released version
2.0.0 of safety. The original report for this bug in the safety
pre-commit hook can be found here:
https://github.com/Lucas-C/pre-commit-hooks-safety/issues/29