### PR TITLE
Replace usage of ILIKE in database statements

### DIFF
--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -69,7 +69,7 @@ class Leaderboard:
             supplied JID
 
         """
-        player = self.db.query(Player).filter(Player.jid.ilike(str(jid))).first()
+        player = self.db.query(Player).filter(func.lower(Player.jid) == str(jid).lower()).first()
         if player:
             return player
 
@@ -92,7 +92,7 @@ class Leaderboard:
 
         """
         stats = {}
-        player = self.db.query(Player).filter(Player.jid.ilike(str(jid))).first()
+        player = self.db.query(Player).filter(func.lower(Player.jid) == str(jid).lower()).first()
 
         if not player:
             logging.debug("Couldn't find profile for player %s", jid)
@@ -184,7 +184,8 @@ class Leaderboard:
         game = Game(map=game_report['mapName'], duration=int(game_report['timeElapsed']),
                     teamsLocked=bool(game_report['teamsLocked']), matchID=game_report['matchID'])
         game.player_info.extend(player_infos)
-        game.winner = self.db.query(Player).filter(Player.jid.ilike(str(winning_jid))).first()
+        game.winner = self.db.query(Player).filter(
+            func.lower(Player.jid) == str(winning_jid).lower()).first()
         self.db.add(game)
         self.db.commit()
         return game


### PR DESCRIPTION
When checking for player items in the leaderboard database, EcheLOn did
use ILIKE for some queries. This caused unexpected behavior which might
have lead to the wrong player item being returned from the database,
when a player JID contained an underscore, as underscores are handled as
single wildcard characters in LIKE-clauses.

This might have very well been the cause for the bug described in
https://trac.wildfiregames.com/ticket/6558.

This commit fixes that by replacing the use of ILIKE for
case-insensitive filtering of player JIDs with explicit filtering based
on the lower case player JID.