### PR TITLE
Add Docker config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.eggs/
+.git/
+.idea/
+.hypothesis/
+.mypy_cache/
+.tox/
+
+*.egg-info/
+
+.coverage
+.coverage.*
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ venv/
 ENV/
 
 .idea
+
+*.sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,104 @@ one to use as command line parameter:
 ```
 tox -e py37
 ```
+
+## Docker
+
+To offer an easy way to run the bots locally for testing, this repository contains a Docker
+Compose configuration to run Docker containers for ejabberd, XpartaMuPP and EcheLOn.
+
+To run the docker containers you need to have [Docker](https://www.docker.com/) and
+[Docker Compose](https://docs.docker.com/compose/install/) installed.
+
+After installing them, you can start the Docker containers like that:
+
+```
+DOCKER_BUILDKIT=1 docker-compose up
+```
+
+Once started there is an ejabberd server running in a Docker container, exposing the ports
+necessary to connect to it on localhost. This ejabberd server has the proper configuration set to
+be used as lobby for pyrogenesis, including a MUC room called `arena` and has accounts registered
+for `xpartamupp`, `echelon`. There also exist three additional accounts (`player1`, `player2`,
+`player3`) for testing purposes. The password for all of these accounts is identical to the
+username. If necessary additional accounts can be created through `ejabberdctl`.
+
+To be able to connect with pyrogenesis to the started ejabberd instance, you'll now need to add an
+entry to your `hosts`-file to resolve `ejabberd` to `127.0.0.1`. If you're running Linux that means
+that you'll need to add the following line to `/etc/hosts`. If you're running another operating
+system the [location of the `hosts`-file](https://en.wikipedia.org/wiki/Hosts_(file)#Location_in_the_file_system)
+might be different.
+
+```
+127.0.0.1   ejabberd
+```
+
+Once done, all which is left to do now is to tell pyrogenesis to use the lobby running in the
+Docker containers. You can do that by starting it with the following command line options. Ensure
+to back up your original configuration before, as starting pyrogenesis like that will overwrite the
+existing config:
+
+```
+pyrogenesis \
+  -conf=lobby.room:arena \
+  -conf=lobby.server:ejabberd \
+  -conf=lobby.stun.enabled:true \
+  -conf=lobby.stun.server:ejabberd \
+  -conf=lobby.xpartamupp:xpartamupp \
+  -conf=lobby.echelon:echelon \
+  -conf=lobby.login:player1 \
+  -conf=lobby.password:player1 \
+  -conf=lobby.tls:false
+```
+
+Do note that it currently isn't possible to successful log in into the lobby when typing the
+password interactively in pyrogenesis, unless the user was created via pyrogenesis as well, as
+pyrogenesis applies client-side hashing of the password and uses the hashed password as actual
+password. So you have to provide the password as a command line parameter as shown above.
+
+### mod_ipstamp
+
+The instructions above don't install `mod_ipstamp`, as `mod_ipstamp` is usually not necessary for
+testing the bots and installing it requires some additional steps after the ejabberd container is
+up. In case you want to in `mod_ipstamp`, here are the commands you need to run to do so:
+
+```
+docker-compose exec ejabberd bin/ejabberdctl module_install mod_ipstamp
+docker-compose exec ejabberd \
+  sed -i 's#^modules:$#modules:\n  mod_ipstamp: {}#g' /opt/ejabberd/conf/ejabberd.yml
+docker-compose exec ejabberd bin/ejabberdctl reload_config
+```
+
+### Persistent ratings database
+
+With the instructions to run the Docker containers above EcheLOn's ratings database is ephemeral
+and will get recreated when rebuilding the Docker images. If you want to have a persistent ratings
+database you can also use outside the Docker Container, a few additional steps are necessary.
+
+First of all you'll need to install the bots itself on your host machine, as they contain a
+command to create database files. You can do that like this:
+
+```
+pip install -e .
+```
+
+As a next step you can create the ratings SQLite database file:
+
+```
+echelon-db create
+```
+
+Depending on your operating system you'll also need to change the file permissions on the newly
+created file to allow the Docker container to access it for reading and writing later on. On Linux
+you can do that with the following command:
+
+```
+setfacl -m u:999:rw lobby_rankings.sqlite3
+```
+
+Finally, you now have to start the Docker container slightly different to mount the created database
+file as volume into EcheLOn's container:
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.persistent-db.yml up
+```

--- a/Dockerfile.echelon
+++ b/Dockerfile.echelon
@@ -1,0 +1,15 @@
+FROM python:3.7-slim
+
+RUN groupadd -r -g 999 python && useradd -m -r -u 999 -g python python
+USER python:python
+WORKDIR /home/python
+COPY --chown=python:python . .
+RUN --mount=type=cache,target=/home/python/.cache,uid=999,gid=999 \
+  pip install --user \
+  --progress-bar off \
+  --no-warn-script-location \
+  --disable-pip-version-check .
+RUN if [ ! -f lobby_rankings.sqlite3 ]; then /home/python/.local/bin/echelon-db create; fi
+
+ENTRYPOINT [ "/home/python/.local/bin/echelon" ]
+CMD ["--debug", "--domain=ejabberd", "--server=ejabberd", "--login=echelon", "--password=echelon"]

--- a/Dockerfile.ejabberd
+++ b/Dockerfile.ejabberd
@@ -1,0 +1,5 @@
+FROM ghcr.io/processone/ejabberd:22.05
+
+COPY --chown=ejabberd:ejabberd ./docker/ejabberd.yml /opt/ejabberd/conf/ejabberd.yml
+RUN mkdir -p /opt/ejabberd/.ejabberd-modules/sources
+COPY --chown=ejabberd:ejabberd mod_ipstamp /opt/ejabberd/.ejabberd-modules/sources/mod_ipstamp

--- a/Dockerfile.xpartamupp
+++ b/Dockerfile.xpartamupp
@@ -1,0 +1,14 @@
+FROM python:3.7-slim
+
+RUN groupadd -r -g 999 python && useradd -m -r -u 999 -g python python
+USER python:python
+WORKDIR /home/python
+COPY --chown=python:python . .
+RUN --mount=type=cache,target=/home/python/.cache,uid=999,gid=999 \
+  pip install --user \
+  --progress-bar off \
+  --no-warn-script-location \
+  --disable-pip-version-check .
+
+ENTRYPOINT [ "/home/python/.local/bin/xpartamupp" ]
+CMD ["--debug", "--domain=ejabberd", "--server=ejabberd", "--login=xpartamupp", "--password=xpartamupp"]

--- a/docker-compose.persistent-db.yml
+++ b/docker-compose.persistent-db.yml
@@ -1,0 +1,7 @@
+---
+services:
+  echelon:
+    volumes:
+      - type: bind
+        source: ./lobby_rankings.sqlite3
+        target: /home/python/lobby_rankings.sqlite3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+services:
+  ejabberd:
+    build:
+      context: .
+      dockerfile: Dockerfile.ejabberd
+    environment:
+      - CTL_ON_CREATE=register admin ejabberd admin ;
+                      register echelon ejabberd echelon ;
+                      register xpartamupp ejabberd xpartamupp ;
+                      register player1 ejabberd player1 ;
+                      register player2 ejabberd player2 ;
+                      register player3 ejabberd player3
+    extra_hosts:
+      - "ejabberd:127.0.0.1"
+    ports:
+      - 3478:3478/udp
+      - 5222:5222
+      - 5280:5280
+      - 5443:5443
+
+  echelon:
+    build:
+      context: .
+      dockerfile: Dockerfile.echelon
+    extra_hosts:
+      - "ejabberd:127.0.0.1"
+    depends_on:
+      - ejabberd
+
+  xpartamupp:
+    build:
+      context: .
+      dockerfile: Dockerfile.xpartamupp
+    extra_hosts:
+      - "ejabberd:127.0.0.1"
+    depends_on:
+      - ejabberd

--- a/docker/ejabberd.yml
+++ b/docker/ejabberd.yml
@@ -1,0 +1,268 @@
+---
+### *******************************************************
+### This ejabberd configuration is only suitable for testing purposes
+### and is only meant to be used for locally running Docker containers!
+### It is not safe to use this productively at all!
+### *******************************************************
+
+###
+###              ejabberd configuration file
+###
+### The parameters used in this configuration file are explained at
+###
+###       https://docs.ejabberd.im/admin/configuration
+###
+### The configuration file is written in YAML.
+### *******************************************************
+### *******           !!! WARNING !!!               *******
+### *******     YAML IS INDENTATION SENSITIVE       *******
+### ******* MAKE SURE YOU INDENT SECTIONS CORRECTLY *******
+### *******************************************************
+### Refer to http://en.wikipedia.org/wiki/YAML for the brief description.
+###
+
+hosts:
+  - localhost
+  - ejabberd
+
+loglevel: debug
+
+ca_file: /opt/ejabberd/conf/cacert.pem
+certfiles:
+  - /opt/ejabberd/conf/server.pem
+
+## If you already have certificates, list them here
+# certfiles:
+#  - /etc/letsencrypt/live/domain.tld/fullchain.pem
+#  - /etc/letsencrypt/live/domain.tld/privkey.pem
+
+listen:
+  -
+    port: 5222
+    ip: "::"
+    module: ejabberd_c2s
+    max_stanza_size: 1048576
+    shaper: c2s_shaper
+    access: c2s
+    starttls_required: false
+  -
+    port: 5223
+    ip: "::"
+    tls: true
+    module: ejabberd_c2s
+    max_stanza_size: 262144
+    shaper: c2s_shaper
+    access: c2s
+    starttls_required: true
+  -
+    port: 5269
+    ip: "::"
+    module: ejabberd_s2s_in
+    max_stanza_size: 524288
+  -
+    port: 5443
+    ip: "::"
+    module: ejabberd_http
+    tls: true
+    request_handlers:
+      /admin: ejabberd_web_admin
+      /api: mod_http_api
+      /bosh: mod_bosh
+      /captcha: ejabberd_captcha
+      /upload: mod_http_upload
+      /ws: ejabberd_http_ws
+  -
+    port: 5280
+    ip: "::"
+    module: ejabberd_http
+    request_handlers:
+      /admin: ejabberd_web_admin
+      /.well-known/acme-challenge: ejabberd_acme
+  -
+    port: 3478
+    ip: "::"
+    transport: udp
+    module: ejabberd_stun
+    use_turn: true
+    ## The server's public IPv4 address:
+    # turn_ipv4_address: "203.0.113.3"
+    ## The server's public IPv6 address:
+    # turn_ipv6_address: "2001:db8::3"
+  -
+    port: 1883
+    ip: "::"
+    module: mod_mqtt
+    backlog: 1000
+
+s2s_use_starttls: optional
+
+acl:
+  local:
+    user_regexp: "^[0-9A-Za-z._-]{1,20}$"
+  loopback:
+    ip:
+      - 127.0.0.0/8
+      - ::1/128
+  admin:
+    user:
+      - "admin@ejabberd"
+  bots:
+    user:
+      - "xpartamupp@ejabberd"
+      - "echelon@ejabberd"
+
+access_rules:
+  local:
+    allow: local
+  c2s:
+    deny: blocked
+    allow: all
+  announce:
+    allow: admin
+  configure:
+    allow: admin
+  muc_create:
+    allow: local
+  muc_admin:
+    - allow: admin
+    - allow: bots
+  pubsub_createnode:
+    allow: local
+  trusted_network:
+    allow: loopback
+  ipbots:
+    allow: bots
+
+api_permissions:
+  "console commands":
+    from:
+      - ejabberd_ctl
+    who: all
+    what: "*"
+  "admin access":
+    who:
+      access:
+        allow:
+          - acl: loopback
+          - acl: admin
+      oauth:
+        scope: "ejabberd:admin"
+        access:
+          allow:
+            - acl: loopback
+            - acl: admin
+    what:
+      - "*"
+      - "!stop"
+      - "!start"
+  "public commands":
+    who:
+      ip: 127.0.0.1/8
+    what:
+      - status
+      - connected_users_number
+
+shaper:
+  normal:
+    rate: 3000
+    burst_size: 20000
+  fast: 100000
+
+shaper_rules:
+  max_user_sessions: 10
+  max_user_offline_messages:
+    5000: admin
+    100: all
+  c2s_shaper:
+    none: admin, bots
+    normal: all
+  s2s_shaper: fast
+
+registration_timeout: infinity
+
+modules:
+  mod_adhoc: {}
+  mod_admin_extra: {}
+  mod_announce:
+    access: announce
+  mod_avatar: {}
+  mod_blocking: {}
+  mod_bosh: {}
+  mod_caps: {}
+  mod_carboncopy: {}
+  mod_client_state: {}
+  mod_configure: {}
+  mod_disco: {}
+  mod_fail2ban: {}
+  mod_http_api: {}
+  mod_http_upload:
+    put_url: https://@HOST@:5443/upload
+    custom_headers:
+      "Access-Control-Allow-Origin": "https://@HOST@"
+      "Access-Control-Allow-Methods": "GET,HEAD,PUT,OPTIONS"
+      "Access-Control-Allow-Headers": "Content-Type"
+  mod_last: {}
+  mod_mam:
+    ## Mnesia is limited to 2GB, better to use an SQL backend
+    ## For small servers SQLite is a good fit and is very easy
+    ## to configure. Uncomment this when you have SQL configured:
+    ## db_type: sql
+    assume_mam_usage: true
+    default: always
+  mod_mqtt: {}
+  mod_muc:
+    access:
+      - allow
+    access_admin: muc_admin
+    access_create: muc_create
+    access_persistent: muc_create
+    access_mam:
+      - allow
+    default_room_options:
+      mam: true
+      allow_change_subj: false
+      persistent: true
+  mod_muc_admin: {}
+  mod_offline:
+    access_max_user_messages: max_user_offline_messages
+  mod_ping: {}
+  mod_privacy: {}
+  mod_private: {}
+  mod_proxy65:
+    access: local
+    max_connections: 5
+  mod_pubsub:
+    access_createnode: pubsub_createnode
+    plugins:
+      - flat
+      - pep
+    force_node_config:
+      ## Avoid buggy clients to make their bookmarks public
+      storage:bookmarks:
+        access_model: whitelist
+  mod_push: {}
+  mod_push_keepalive: {}
+  mod_register:
+    ## Only accept registration requests from the "trusted"
+    ## network (see access_rules section above).
+    ## Think twice before enabling registration from any
+    ## address. See the Jabber SPAM Manifesto for details:
+    ## https://github.com/ge0rg/jabber-spam-fighting-manifesto
+    ip_access: trusted_network
+    access: register
+  mod_roster:
+    versioning: true
+  mod_s2s_dialback: {}
+  mod_shared_roster: {}
+  mod_stream_mgmt:
+    resend_on_timeout: if_offline
+  mod_stun_disco: {}
+  mod_vcard: {}
+  mod_vcard_xupdate: {}
+  mod_version:
+    show_os: false
+
+### Local Variables:
+### mode: yaml
+### End:
+### vim: set filetype=yaml tabstop=8


### PR DESCRIPTION
This adds everything necessary to use Docker Compose to start a local
stack of ejabberd, XpartaMuPP and EcheLOn. This is meant as a quick and
easy way to get a lobby setup up and running for local testing and
development.