### PR TITLE
Fix unencrypted connections to XMPP server

### DIFF
--- a/tests/test_echelon.py
+++ b/tests/test_echelon.py
@@ -204,6 +204,6 @@ class TestMain(TestCase):
                                                           call('xep_0045'), call('xep_0060'),
                                                           call('xep_0199', {'keepalive': True})],
                                                          any_order=True)
-            xmpp_mock().connect.assert_called_once_with(None, True, True)
+            xmpp_mock().connect.assert_called_once_with(None, disable_starttls=False)
             asyncio_mock.get_event_loop.assert_called_once_with()
             asyncio_mock.get_event_loop.return_value.run_forever_assert_called_once_with()

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -162,6 +162,6 @@ class TestMain(TestCase):
                                                           call('xep_0045'), call('xep_0060'),
                                                           call('xep_0199', {'keepalive': True})],
                                                          any_order=True)
-            xmpp_mock().connect.assert_called_once_with(None, True, True)
+            xmpp_mock().connect.assert_called_once_with(None, disable_starttls=False)
             asyncio_mock.get_event_loop.assert_called_once_with()
             asyncio_mock.get_event_loop.return_value.run_forever_assert_called_once_with()

--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -860,9 +860,9 @@ def main():
     xmpp.register_plugin('xep_0199', {'keepalive': True})  # XMPP Ping
 
     if args.xserver:
-        xmpp.connect((args.xserver, 5222))
+        xmpp.connect((args.xserver, 5222), disable_starttls=args.xdisabletls)
     else:
-        xmpp.connect(None, True, not args.xdisabletls)
+        xmpp.connect(None, disable_starttls=args.xdisabletls)
 
     asyncio.get_event_loop().run_until_complete(xmpp.shutdown)
 

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -400,9 +400,9 @@ def main():
     xmpp.register_plugin('xep_0199', {'keepalive': True})  # XMPP Ping
 
     if args.xserver:
-        xmpp.connect((args.xserver, 5222))
+        xmpp.connect((args.xserver, 5222), disable_starttls=args.xdisabletls)
     else:
-        xmpp.connect(None, True, not args.xdisabletls)
+        xmpp.connect(None, disable_starttls=args.xdisabletls)
 
     asyncio.get_event_loop().run_until_complete(xmpp.shutdown)
 


### PR DESCRIPTION
219ce9f broke unencrypted connections to the XMPP server when using the `--disable-tls` flag, as SleekXMPP and Slixmpp require different parameters for `ClientXMPP.connect()`. This commit fixes that again.