### PR TITLE
Don't show stale games anymore

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -4,6 +4,10 @@ strictness: veryhigh
 doc-warnings: true
 test-warnings: true
 
+mccabe:
+  options:
+    max-complexity: 11
+
 pep8:
   options:
     max-line-length: 99

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -320,14 +320,18 @@ class XpartaMuPP(ClientXMPP):
         """
         games = self.games.get_all_games()
 
+        online_jids = []
+        for nick in self.plugin['xep_0045'].get_roster(self.room):
+            online_jids.append(JID(self.plugin['xep_0045'].get_jid_property(self.room, nick,
+                                                                            'jid')))
+
         stanza = GameListXmppPlugin()
         for jid in games:
-            stanza.add_game(games[jid])
+            if jid in online_jids:
+                stanza.add_game(games[jid])
 
         if not to:
-            for nick in self.plugin['xep_0045'].get_roster(self.room):
-                jid = JID(self.plugin['xep_0045'].get_jid_property(self.room, nick, 'jid'))
-
+            for jid in online_jids:
                 if not jid.resource.startswith('0ad'):
                     continue
 


### PR DESCRIPTION
Up until now we had the problem that stale games would be shown when XpartaMuPP didn't receive the "got_offline" event when a player hosting a game left the MUC. While it's unknown what causes XpartaMuPP not receive such events from time to time, it's something which happened regularly.

This commit fixes that by only returning games to players where the hosting player is present in the MUC as well. As we don't know if the hosting player stopped hosting a game or just had a short disconnect from ejabberd, this just filters the list of returned games and doesn't delete games in there. This should handle hosting players temporarily dropping out of the MUC quite well and does only show their game again once they rejoin and don't start hosting another game.