### PR TITLE
Remove redundant passing of sys.argv[1:]

### DIFF
--- a/tests/test_echelon.py
+++ b/tests/test_echelon.py
@@ -167,7 +167,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_valid(self, cmd_args, expected_args):
         """Test valid parameter combinations."""
-        self.assertEqual(parse_args(cmd_args), expected_args)
+        with patch.object(sys, 'argv', ['echelon'] + cmd_args):
+            self.assertEqual(expected_args, parse_args())
 
     @parameterized.expand([
         (['-f'],),
@@ -179,8 +180,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_invalid(self, cmd_args):
         """Test invalid parameter combinations."""
-        with self.assertRaises(SystemExit):
-            parse_args(cmd_args)
+        with patch.object(sys, 'argv', ['echelon'] + cmd_args), self.assertRaises(SystemExit):
+            parse_args()
 
 
 class TestMain(TestCase):
@@ -198,7 +199,7 @@ class TestMain(TestCase):
                                           database_url='sqlite:///lobby_rankings.sqlite3',
                                           xserver=None, xdisabletls=False)
             main()
-            args_mock.assert_called_once_with(sys.argv[1:])
+            args_mock.assert_called_once_with()
             leaderboard_mock.assert_called_once_with('sqlite:///lobby_rankings.sqlite3')
             xmpp_mock().register_plugin.assert_has_calls([call('xep_0004'), call('xep_0030'),
                                                           call('xep_0045'), call('xep_0060'),

--- a/tests/test_lobby_ranking.py
+++ b/tests/test_lobby_ranking.py
@@ -37,7 +37,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_valid(self, cmd_args, expected_args):
         """Test valid parameter combinations."""
-        self.assertEqual(parse_args(cmd_args), expected_args)
+        with patch.object(sys, 'argv', ['echelon-db'] + cmd_args):
+            self.assertEqual(parse_args(), expected_args)
 
     @parameterized.expand([
         ([],),
@@ -45,8 +46,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_missing_action(self, cmd_args):
         """Test invalid parameter combinations."""
-        with self.assertRaises(SystemExit):
-            parse_args(cmd_args)
+        with patch.object(sys, 'argv', ['echelon-db'] + cmd_args), self.assertRaises(SystemExit):
+            parse_args()
 
 
 class TestMain(TestCase):
@@ -62,7 +63,7 @@ class TestMain(TestCase):
             engine_mock = Mock()
             create_engine_mock.return_value = engine_mock
             main()
-            args_mock.assert_called_once_with(sys.argv[1:])
+            args_mock.assert_called_once_with()
             create_engine_mock.assert_called_once_with(
                 'sqlite:///lobby_rankings.sqlite3')
             declarative_base_mock.metadata.create_all.assert_any_call(engine_mock)

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -128,7 +128,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_valid(self, cmd_args, expected_args):
         """Test valid parameter combinations."""
-        self.assertEqual(parse_args(cmd_args), expected_args)
+        with patch.object(sys, 'argv', ['xpartamupp'] + cmd_args):
+            self.assertEqual(parse_args(), expected_args)
 
     @parameterized.expand([
         (['-f'],),
@@ -140,8 +141,8 @@ class TestArgumentParsing(TestCase):
     ])
     def test_invalid(self, cmd_args):
         """Test invalid parameter combinations."""
-        with self.assertRaises(SystemExit):
-            parse_args(cmd_args)
+        with patch.object(sys, 'argv', ['xpartamupp'] + cmd_args), self.assertRaises(SystemExit):
+            parse_args()
 
 
 class TestMain(TestCase):
@@ -157,7 +158,7 @@ class TestMain(TestCase):
                                           room='arena', nickname='WFGBot',
                                           xserver=None, xdisabletls=False)
             main()
-            args_mock.assert_called_once_with(sys.argv[1:])
+            args_mock.assert_called_once_with()
             xmpp_mock().register_plugin.assert_has_calls([call('xep_0004'), call('xep_0030'),
                                                           call('xep_0045'), call('xep_0060'),
                                                           call('xep_0199', {'keepalive': True})],

--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -22,7 +22,6 @@ import argparse
 import asyncio
 import difflib
 import logging
-import sys
 
 from asyncio import Future
 from collections import deque
@@ -803,11 +802,8 @@ class EcheLOn(ClientXMPP):
             logging.exception("Failed to send profile to %s", iq['to'])
 
 
-def parse_args(args):
+def parse_args():
     """Parse command line arguments.
-
-    Arguments:
-        args (dict): Raw command line arguments given to the script
 
     Returns:
          Parsed command line arguments
@@ -839,12 +835,12 @@ def parse_args(args):
                         help='Pass this argument to connect without TLS encryption',
                         action='store_true', dest='xdisabletls', default=False)
 
-    return parser.parse_args(args)
+    return parser.parse_args()
 
 
 def main():
     """Entry point a console script."""
-    args = parse_args(sys.argv[1:])
+    args = parse_args()
 
     logging.basicConfig(level=args.log_level,
                         format='%(asctime)s %(levelname)-8s %(message)s',

--- a/xpartamupp/lobby_ranking.py
+++ b/xpartamupp/lobby_ranking.py
@@ -19,7 +19,6 @@
 """Database schema used by the XMPP bots to store game information."""
 
 import argparse
-import sys
 
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -145,11 +144,8 @@ class Game(Base):
     winner = relationship('Player', back_populates='games_won')
 
 
-def parse_args(args):
+def parse_args():
     """Parse command line arguments.
-
-    Arguments:
-        args (dict): Raw command line arguments given to the script
 
     Returns:
          Parsed command line arguments
@@ -161,12 +157,12 @@ def parse_args(args):
                         choices=['create'])
     parser.add_argument('--database-url', help='URL for the leaderboard database',
                         default='sqlite:///lobby_rankings.sqlite3')
-    return parser.parse_args(args)
+    return parser.parse_args()
 
 
 def main():
     """Entry point a console script."""
-    args = parse_args(sys.argv[1:])
+    args = parse_args()
     engine = create_engine(args.database_url)
     if args.action == 'create':
         Base.metadata.create_all(engine)

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -20,7 +20,6 @@
 import argparse
 import asyncio
 import logging
-import sys
 import time
 
 from asyncio import Future
@@ -350,11 +349,8 @@ class XpartaMuPP(ClientXMPP):
                 logging.exception("Failed to send game list to %s", to)
 
 
-def parse_args(args):
+def parse_args():
     """Parse command line arguments.
-
-    Arguments:
-        args (dict): Raw command line arguments given to the script
 
     Returns:
          Parsed command line arguments
@@ -384,12 +380,12 @@ def parse_args(args):
                         help='Pass this argument to connect without TLS encryption',
                         action='store_true', dest='xdisabletls', default=False)
 
-    return parser.parse_args(args)
+    return parser.parse_args()
 
 
 def main():
     """Entry point a console script."""
-    args = parse_args(sys.argv[1:])
+    args = parse_args()
 
     logging.basicConfig(level=args.log_level,
                         format='%(asctime)s %(levelname)-8s %(message)s',


### PR DESCRIPTION
`argparse.ArgumentParser().parse_args()` already defaults to use `sys.argv[1:]` when no `args` are provided. This removes unnecessary code which did explicitly pass `sys.argv[1:]`.