### PR TITLE
Always use TLS-encryption for connections

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -16,7 +16,7 @@ pep8:
 
 pylint:
   options:
-    max-args: 6
+    max-args: 8
     max-attributes: 10
     max-line-length: 99
   disable:

--- a/tests/test_echelon.py
+++ b/tests/test_echelon.py
@@ -124,46 +124,42 @@ class TestArgumentParsing(TestCase):
     @parameterized.expand([
         ([],
          Namespace(domain='lobby.wildfiregames.com', login='EcheLOn', log_level=30, xserver=None,
-                   xdisabletls=False,
-                   nickname='RatingsBot', password='XXXXXX', room='arena',
+                   no_verify=False, nickname='RatingsBot', password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['--debug'],
          Namespace(domain='lobby.wildfiregames.com', login='EcheLOn', log_level=10, xserver=None,
-                   xdisabletls=False,
-                   nickname='RatingsBot', password='XXXXXX', room='arena',
+                   no_verify=False, nickname='RatingsBot', password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['--quiet'],
          Namespace(domain='lobby.wildfiregames.com', login='EcheLOn', log_level=40, xserver=None,
-                   xdisabletls=False,
-                   nickname='RatingsBot', password='XXXXXX', room='arena',
+                   no_verify=False, nickname='RatingsBot', password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['--verbose'],
          Namespace(domain='lobby.wildfiregames.com', login='EcheLOn', log_level=20, xserver=None,
-                   xdisabletls=False,
-                   nickname='RatingsBot', password='XXXXXX', room='arena',
+                   no_verify=False, nickname='RatingsBot', password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['-m', 'lobby.domain.tld'],
          Namespace(domain='lobby.domain.tld', login='EcheLOn', log_level=30, nickname='RatingsBot',
-                   xserver=None, xdisabletls=False,
-                   password='XXXXXX', room='arena',
+                   xserver=None, no_verify=False, password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['--domain=lobby.domain.tld'],
          Namespace(domain='lobby.domain.tld', login='EcheLOn', log_level=30, nickname='RatingsBot',
-                   xserver=None, xdisabletls=False,
-                   password='XXXXXX', room='arena',
+                   xserver=None, no_verify=False, password='XXXXXX', room='arena',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['-m', 'lobby.domain.tld', '-l', 'bot', '-p', '123456', '-n', 'Bot', '-r', 'arena123',
           '-v'],
          Namespace(domain='lobby.domain.tld', login='bot', log_level=20, nickname='Bot',
-                   xserver=None, xdisabletls=False,
-                   password='123456', room='arena123',
+                   xserver=None, no_verify=False, password='123456', room='arena123',
                    database_url='sqlite:///lobby_rankings.sqlite3')),
         (['--domain=lobby.domain.tld', '--login=bot', '--password=123456', '--nickname=Bot',
           '--room=arena123', '--database-url=sqlite:////tmp/db.sqlite3', '--verbose'],
          Namespace(domain='lobby.domain.tld', login='bot', log_level=20, nickname='Bot',
-                   xserver=None, xdisabletls=False,
-                   password='123456', room='arena123',
+                   xserver=None, no_verify=False, password='123456', room='arena123',
                    database_url='sqlite:////tmp/db.sqlite3')),
+        (['--no-verify'],
+         Namespace(domain='lobby.wildfiregames.com', login='EcheLOn', log_level=30, xserver=None,
+                   no_verify=True, nickname='RatingsBot', password='XXXXXX', room='arena',
+                   database_url='sqlite:///lobby_rankings.sqlite3')),
     ])
     def test_valid(self, cmd_args, expected_args):
         """Test valid parameter combinations."""
@@ -197,7 +193,7 @@ class TestMain(TestCase):
                                           domain='lobby.wildfiregames.com', password='XXXXXX',
                                           room='arena', nickname='RatingsBot',
                                           database_url='sqlite:///lobby_rankings.sqlite3',
-                                          xserver=None, xdisabletls=False)
+                                          xserver=None, no_verify=False)
             main()
             args_mock.assert_called_once_with()
             leaderboard_mock.assert_called_once_with('sqlite:///lobby_rankings.sqlite3')
@@ -205,6 +201,6 @@ class TestMain(TestCase):
                                                           call('xep_0045'), call('xep_0060'),
                                                           call('xep_0199', {'keepalive': True})],
                                                          any_order=True)
-            xmpp_mock().connect.assert_called_once_with(None, disable_starttls=False)
+            xmpp_mock().connect.assert_called_once_with(None)
             asyncio_mock.get_event_loop.assert_called_once_with()
             asyncio_mock.get_event_loop.return_value.run_forever_assert_called_once_with()

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -93,38 +93,38 @@ class TestArgumentParsing(TestCase):
 
     @parameterized.expand([
         ([], Namespace(domain='lobby.wildfiregames.com', login='xpartamupp', log_level=30,
-                       xserver=None, xdisabletls=False,
+                       xserver=None, no_verify=False,
                        nickname='WFGBot', password='XXXXXX', room='arena')),
         (['--debug'],
          Namespace(domain='lobby.wildfiregames.com', login='xpartamupp', log_level=10,
-                   xserver=None, xdisabletls=False,
+                   xserver=None, no_verify=False,
                    nickname='WFGBot', password='XXXXXX', room='arena')),
         (['--quiet'],
          Namespace(domain='lobby.wildfiregames.com', login='xpartamupp', log_level=40,
-                   xserver=None, xdisabletls=False,
+                   xserver=None, no_verify=False,
                    nickname='WFGBot', password='XXXXXX', room='arena')),
         (['--verbose'],
          Namespace(domain='lobby.wildfiregames.com', login='xpartamupp', log_level=20,
-                   xserver=None, xdisabletls=False,
+                   xserver=None, no_verify=False,
                    nickname='WFGBot', password='XXXXXX', room='arena')),
         (['-m', 'lobby.domain.tld'],
          Namespace(domain='lobby.domain.tld', login='xpartamupp', log_level=30, nickname='WFGBot',
-                   xserver=None, xdisabletls=False,
-                   password='XXXXXX', room='arena')),
+                   xserver=None, no_verify=False, password='XXXXXX', room='arena')),
         (['--domain=lobby.domain.tld'],
          Namespace(domain='lobby.domain.tld', login='xpartamupp', log_level=30, nickname='WFGBot',
-                   xserver=None, xdisabletls=False,
-                   password='XXXXXX', room='arena')),
+                   xserver=None, no_verify=False, password='XXXXXX', room='arena')),
         (['-m', 'lobby.domain.tld', '-l', 'bot', '-p', '123456', '-n', 'Bot', '-r', 'arena123',
           '-v'],
          Namespace(domain='lobby.domain.tld', login='bot', log_level=20, xserver=None,
-                   xdisabletls=False,
-                   nickname='Bot', password='123456', room='arena123')),
+                   no_verify=False, nickname='Bot', password='123456', room='arena123')),
         (['--domain=lobby.domain.tld', '--login=bot', '--password=123456', '--nickname=Bot',
           '--room=arena123', '--verbose'],
          Namespace(domain='lobby.domain.tld', login='bot', log_level=20, xserver=None,
-                   xdisabletls=False,
-                   nickname='Bot', password='123456', room='arena123')),
+                   no_verify=False, nickname='Bot', password='123456', room='arena123')),
+        (['--no-verify'],
+         Namespace(domain='lobby.wildfiregames.com', login='xpartamupp', log_level=30,
+                   xserver=None, no_verify=True,
+                   nickname='WFGBot', password='XXXXXX', room='arena')),
     ])
     def test_valid(self, cmd_args, expected_args):
         """Test valid parameter combinations."""
@@ -156,13 +156,13 @@ class TestMain(TestCase):
             args_mock.return_value = Mock(log_level=30, login='xpartamupp',
                                           domain='lobby.wildfiregames.com', password='XXXXXX',
                                           room='arena', nickname='WFGBot',
-                                          xserver=None, xdisabletls=False)
+                                          xserver=None, no_verify=False)
             main()
             args_mock.assert_called_once_with()
             xmpp_mock().register_plugin.assert_has_calls([call('xep_0004'), call('xep_0030'),
                                                           call('xep_0045'), call('xep_0060'),
                                                           call('xep_0199', {'keepalive': True})],
                                                          any_order=True)
-            xmpp_mock().connect.assert_called_once_with(None, disable_starttls=False)
+            xmpp_mock().connect.assert_called_once_with(None)
             asyncio_mock.get_event_loop.assert_called_once_with()
             asyncio_mock.get_event_loop.return_value.run_forever_assert_called_once_with()

--- a/xpartamupp/stanzas.py
+++ b/xpartamupp/stanzas.py
@@ -140,7 +140,7 @@ class ProfileXmppPlugin(ElementBase):
         """
         self.xml.append(ET.fromstring('<command>%s</command>' % player_nick))
 
-    def add_item(self, player, rating, highest_rating=0,  # pylint: disable=too-many-arguments
+    def add_item(self, player, rating, highest_rating=0,
                  rank=0, total_games_played=0, wins=0, losses=0):
         """Add an item to the extension.
 


### PR DESCRIPTION
Up to now the bots supported unencryped connections to the XMPP server when providing the `--disable-tls` command line option. This had two use cases:

1. Testing with a local XMPP server where no TLS certificate signed by a trusted CA, but instead in most cases just a self-signed certificate, was available.
2. Connecting the bots through `localhost` as host name to the XMPP server, to ensure that traffic doesn't do a roundtrip over the public network, which did result in a mismatch of the host name of the TLS certificate and the actual host name (`localhost`).

As we want to transition to a setup with an XMPP server with unencrypted connections being disabled for security and privacy reasons at some point in future, we need to support these two use cases in a different way. That's what this commit implements. Instead of offering the option to disable the use of TLS for connections to the XMPP server, it adds an option (`--no-verify`) to not verify the certificate presented by the XMPP server. This allows connecting to an XMPP server which only offers a self-signed certificate or whose host name doesn't match the one from the certificate.

This change also has the benefit that communication between the bots and the XMPP server is now always encrypted and a passive observer won't be able to listen to it anymore.