### PR TITLE
Remove safety pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,11 +47,6 @@ repos:
           - ./.tox,./.eggs
           - .
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.0
-    hooks:
-      - id: python-safety-dependencies-check
-
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.31.1
     hooks:


### PR DESCRIPTION
The safety pre-commit hook didn't provide much benefit, as we don't pin dependencies to specific versions. Also very similar functionality is already provided by Github's Dependabot.