### PR TITLE
Disallow options for ModBot commands

### DIFF
--- a/xpartamupp/modbot.py
+++ b/xpartamupp/modbot.py
@@ -55,6 +55,7 @@ class ModCmdParser(ArgumentParser):
         """
         kwargs["add_help"] = False
         kwargs["exit_on_error"] = False
+        kwargs["prefix_chars"] = [None]
         super().__init__(*args, **kwargs)
         self._positionals = self.add_argument_group("arguments")
 


### PR DESCRIPTION
Up to now using a word in a ModBot reason argument which started with a hypen would ModBot not to process the command, as its argparse parser would consider that word as an not existing option. As we don't use options and only use arguments for ModBot commands, this disables option detection for the argparse parser. While this isn't officially supported by argparse, using a list with `None` as only item for the prefix characters, which are supposed to be a string instead of a list, does achieve exactly that.