### PR TITLE
Replace LimitedSizeDict with cachetools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Topic :: Internet :: XMPP",
 ]
 dependencies = [
+    "cachetools",
     "defusedxml",
     "dateparser",
     "slixmpp>=1.8.0",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,31 +21,7 @@ from io import BytesIO, StringIO
 from unittest import TestCase
 from unittest.mock import patch
 
-from hypothesis import given
-from hypothesis import strategies as st
-
-from xpartamupp.utils import ArgumentParserWithConfigFile, LimitedSizeDict
-
-
-class TestLimitedSizeDict(TestCase):
-    """Test limited size dict."""
-
-    @given(st.integers(min_value=2, max_value=2**10))
-    def test_max_items(self, size_limit):
-        """Test max items of dicts.
-
-        Test that the dict doesn't grow indefinitely and that the
-        oldest entries are removed first.
-        """
-        test_dict = LimitedSizeDict(size_limit=size_limit)
-        for i in range(size_limit):
-            test_dict[i] = i
-        self.assertEqual(size_limit, len(test_dict))
-        test_dict[size_limit + 1] = size_limit + 1
-        self.assertEqual(size_limit, len(test_dict))
-        self.assertFalse(0 in test_dict.values())
-        self.assertTrue(1 in test_dict.values())
-        self.assertTrue(size_limit + 1 in test_dict.values())
+from xpartamupp.utils import ArgumentParserWithConfigFile
 
 
 class TestArgumentParserWithConfigFile(TestCase):

--- a/tests/test_xpartamupp.py
+++ b/tests/test_xpartamupp.py
@@ -22,6 +22,7 @@ from argparse import Namespace
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
+from cachetools import FIFOCache
 from parameterized import parameterized
 from slixmpp.jid import JID
 
@@ -41,7 +42,8 @@ class TestGames(TestCase):
         all_games = games.get_all_games()
         game_data.update({'players-init': game_data['players'], 'nbp-init': game_data['nbp'],
                           'state': game_data['state']})
-        self.assertDictEqual(all_games, {jid: game_data})
+        self.assertIsInstance(all_games, FIFOCache)
+        self.assertDictEqual(dict(all_games), {jid: game_data})
 
     @parameterized.expand([
         ('', {}),
@@ -68,11 +70,12 @@ class TestGames(TestCase):
                            'state': game_data1['state']})
         game_data2.update({'players-init': game_data2['players'], 'nbp-init': game_data2['nbp'],
                            'state': game_data2['state']})
-        self.assertDictEqual(games.get_all_games(), {jid1: game_data1, jid2: game_data2})
+        self.assertIsInstance(games.get_all_games(), FIFOCache)
+        self.assertDictEqual(dict(games.get_all_games()), {jid1: game_data1, jid2: game_data2})
         games.remove_game(jid1)
-        self.assertDictEqual(games.get_all_games(), {jid2: game_data2})
+        self.assertDictEqual(dict(games.get_all_games()), {jid2: game_data2})
         games.remove_game(jid2)
-        self.assertDictEqual(games.get_all_games(), {})
+        self.assertDictEqual(dict(games.get_all_games()), {})
 
     def test_remove_unknown(self):
         """Test removal of a game, which doesn't exist."""

--- a/xpartamupp/utils.py
+++ b/xpartamupp/utils.py
@@ -19,37 +19,7 @@
 import tomllib
 
 from argparse import ArgumentParser, Namespace
-from collections import OrderedDict
 from typing import Sequence
-
-
-class LimitedSizeDict(OrderedDict):
-    """Dictionary with limited size and FIFO characteristics."""
-
-    def __init__(self, *args, **kwargs):
-        """Initialize the dictionary.
-
-        Set the limit to which size the dict should be able to grow.
-        """
-        self.size_limit = kwargs.pop('size_limit', None)
-        OrderedDict.__init__(self, *args, **kwargs)
-        self._check_size_limit()
-
-    def __setitem__(self, key, value):
-        """Overwrite default method to add size limit check."""
-        OrderedDict.__setitem__(self, key, value)
-        self._check_size_limit()
-
-    def _check_size_limit(self):
-        """Ensure dict is not larger than the size limit.
-
-        Compares the current size of the dict with the size limit and
-        removes items from the dict until the size is equal the size
-        limit.
-        """
-        if self.size_limit:
-            while len(self) > self.size_limit:
-                self.popitem(last=False)
 
 
 class ArgumentParserWithConfigFile(ArgumentParser):

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -26,6 +26,7 @@ from argparse import ArgumentDefaultsHelpFormatter
 from asyncio import Future
 from datetime import datetime, timedelta, timezone
 
+from cachetools import FIFOCache
 from slixmpp import ClientXMPP
 from slixmpp.jid import JID
 from slixmpp.stanza import Iq
@@ -34,7 +35,7 @@ from slixmpp.xmlstream.matcher import StanzaPath
 from slixmpp.xmlstream.stanzabase import register_stanza_plugin
 
 from xpartamupp.stanzas import GameListXmppPlugin
-from xpartamupp.utils import ArgumentParserWithConfigFile, LimitedSizeDict
+from xpartamupp.utils import ArgumentParserWithConfigFile
 
 # Number of seconds to not respond to mentions after having responded
 # to a mention.
@@ -48,7 +49,7 @@ class Games:
 
     def __init__(self):
         """Initialize with empty games."""
-        self.games = LimitedSizeDict(size_limit=2 ** 7)
+        self.games = FIFOCache(maxsize=2 ** 7)
 
     def add_game(self, jid, data):
         """Add a game.


### PR DESCRIPTION
When receiving game reports from Pyrogenesis, it regularly happens that we never receive a report from both players of a rated game. This happens in the following situations:

1. One of the player rage-quits by force-closing Pyrogenesis.
2. One player looses lobby connectivity during the game.
3. The rated game has only one human player and the other player is a bot (while Pyrogenesis shouldn't send reports for such games, here we are right now).

As we cache game reports in memory until we received and compared them from both players of a rated game, this means that the `LimitedSizeDict` used for that would reach its maximum size of 4096 items pretty fast. While that doesn't impact functionality, it's using up way more memory than necessary.

Additionally EcheLOn contained a bug which wouldn't even remove games from the `LimitedSizeDict`, where we did receive all reports for.

While we can (and actually do in this commit) fix the bug in EcheLOn, we have no control over the situations where we don't receive reports from both players. However, what we can do is to remove reports for games where we're pretty certain, that we'll never receive the missing report anymore.

To do so, this commit replaces the custom `LimitedSizeDict` class with a dependency on `cachetools`. For tracking reports from rated games a size-limited `TTLCache` is now used which evicts reports belonging to games after 1 hour, as we don't expect to receive reports later than a few seconds after the end of a rated game.

This should result in a significant reduction of the memory required by EcheLOn.