### PR TITLE
Send IQ response for gamereport requests

### DIFF
--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -678,10 +678,15 @@ class EcheLOn(ClientXMPP):
         if not iq['from'].resource.startswith('0ad'):
             return
 
+        iq_r = iq.reply()
+
         try:
             self.report_manager.add_report(iq['from'], iq['gamereport']['game'])
         except Exception:
             logger.exception("Failed to update game statistics for %s", iq['from'].bare)
+            iq_r["error"]["condition"] = "internal-server-error"
+
+        iq_r.send()
 
         rating_messages = self.leaderboard.get_rating_messages()
         if rating_messages:


### PR DESCRIPTION
XMPP demands a response for every IQ get/set stanza. This wasn't the case for gamereport requests yet, so this commit adds it.

While Pyrogenesis neither expects nor handles these responses, it doesn't result in any problems either.