### PR TITLE
Limit the length of game names to 256 characters

### DIFF
--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -66,6 +66,7 @@ class Games:
             data["players-init"] = data["players"]
             data["nbp-init"] = data["nbp"]
             data["state"] = "init"
+            data["name"] = data["name"][:256]
         except (KeyError, TypeError, ValueError):
             logger.warning("Received invalid data for add game from %s: %s", jid, data)
             return False


### PR DESCRIPTION
This limits the maximum length of game names to 256 characters. Longer game names will be simply cut to the first 256 characters. While Pyrogenesis already contains a check to limit the game name to 256 characters, this is to counter modified clients trying to circumvent this limitation.

Fixes https://gitea.wildfiregames.com/0ad/0ad/issues/3651