### PR TITLE
Increase cooldown for bot info messages

### DIFF
--- a/xpartamupp/echelon.py
+++ b/xpartamupp/echelon.py
@@ -50,7 +50,7 @@ LEADERBOARD_DEFAULT_RATING = 1200
 
 # Number of seconds to not respond to mentions after having responded
 # to a mention.
-INFO_MSG_COOLDOWN_SECONDS = 120
+INFO_MSG_COOLDOWN_SECONDS = 15 * 60
 
 logger = logging.getLogger(__name__)
 

--- a/xpartamupp/modbot.py
+++ b/xpartamupp/modbot.py
@@ -65,7 +65,7 @@ from xpartamupp.utils import ArgumentParserWithConfigFile
 
 # Number of seconds to not respond to mentions after having responded
 # to a mention.
-INFO_MSG_COOLDOWN_SECONDS = 120
+INFO_MSG_COOLDOWN_SECONDS = 15 * 60
 
 logger = logging.getLogger(__name__)
 

--- a/xpartamupp/xpartamupp.py
+++ b/xpartamupp/xpartamupp.py
@@ -39,7 +39,7 @@ from xpartamupp.utils import ArgumentParserWithConfigFile
 
 # Number of seconds to not respond to mentions after having responded
 # to a mention.
-INFO_MSG_COOLDOWN_SECONDS = 120
+INFO_MSG_COOLDOWN_SECONDS = 15 * 60
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
As the bots get still mentioned quite frequently in the lobby, this increases their cooldown time for info messages from 2 minutes to 15 minutes, to reduce the amount of messages they post.