### PR TITLE
Fix crash of moderation bot for invalid nicknames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,4 @@ convention = "pep257"
 [tool.ruff.lint.pylint]
 max-args = 10
 max-nested-blocks = 4
+max-returns = 8


### PR DESCRIPTION
When invoking the moderation bot with a command targeting a user with an invalid invalid nickname, containing characters not allowed as local part of a JID, the bot would throw an unhandled exception. This would for example happen when copy & pasting such nicknames, while they were surrounded by unprintable Unicode character. To fix this, this commit strips all unprintable characters from the provided nickname and prints an error if it's then still not a valid local part of a JID.