### PR TITLE
Fix storing "en" twice as language for profanity

### DIFF
--- a/xpartamupp/modbot.py
+++ b/xpartamupp/modbot.py
@@ -505,7 +505,7 @@ class ModBot(ClientXMPP):
                 key for key, value in detected_languages_sorted if key != "unk" and value == 1.0
             )
             if not languages:
-                languages = (detected_languages_sorted[0][0], "en")
+                languages = tuple(dict.fromkeys([detected_languages_sorted[0][0], "en"]))
             logger.debug(
                 'Detected languages "%s" for the following text: "%s"',
                 ", ".join(languages),


### PR DESCRIPTION
If text being scanned for profanity couldn't be associated with complete certainty to a single language, we add English as fallback language to the list of detected languages. However, if the detected language was English as well, we did end up with storing "en" twice for the detected languages. This commit fixes that, so "en" is only stored once. While using a set for removing duplicates would've been the most natural solution, we can't use that, as we need to preserve the order of languages. Therefore dict.fromkeys() is used instead.