### PR TITLE
Fix possible runtime error when reconnecting

### DIFF
--- a/xpartamupp/modbot.py
+++ b/xpartamupp/modbot.py
@@ -373,7 +373,7 @@ class ModBot(ClientXMPP):
         also cancels all running unmute tasks. These tasks are being
         rescheduled once a new connection got established.
         """
-        for key in self.unmute_tasks:
+        for key in list(self.unmute_tasks):
             try:
                 task = self.unmute_tasks.pop(key)
             except KeyError:


### PR DESCRIPTION
This fixes a runtime error, when there are unmute tasks while trying to reconnect. The error was caused by trying to change the dictionary while iterating over it.